### PR TITLE
fix: Typo in plugin description

### DIFF
--- a/WeaponPaints.cs
+++ b/WeaponPaints.cs
@@ -19,7 +19,7 @@ namespace WeaponPaints;
 public class WeaponPaints : BasePlugin, IPluginConfig<WeaponPaintsConfig>
 {
 	public override string ModuleName => "WeaponPaints";
-	public override string ModuleDescription => "Connector for web-based player chosen wepaon paints, and standalone for knife.";
+	public override string ModuleDescription => "Connector for web-based player chosen weapon paints, and standalone for knife.";
 	public override string ModuleAuthor => "Nereziel";
 	public override string ModuleVersion => "1.0";
 	public WeaponPaintsConfig Config { get; set; } = new();


### PR DESCRIPTION
![image](https://github.com/Nereziel/cs2-WeaponPaints/assets/32937653/9206ee20-582f-4cc7-8f80-7d637fa0e764)
