### PR TITLE
Some fixes and changes for dev branch.

### DIFF
--- a/Commands.cs
+++ b/Commands.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Modules.Commands;
@@ -40,6 +40,7 @@ namespace WeaponPaints
 						GivePlayerGloves(player);
 						GivePlayerAgent(player);
 						GivePlayerMusicKit(player);
+						GivePlayerPin(player);
 						RefreshWeapons(player);
 					}
 

--- a/Commands.cs
+++ b/Commands.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Modules.Commands;
@@ -40,8 +40,9 @@ namespace WeaponPaints
 						GivePlayerGloves(player);
 						GivePlayerAgent(player);
 						GivePlayerMusicKit(player);
-						GivePlayerPin(player);
 						RefreshWeapons(player);
+						AddTimer(0.1f, () => GivePlayerPin(player));
+						AddTimer(0.15f, () => GivePlayerPin(player));
 					}
 
 					if (!string.IsNullOrEmpty(Localizer["wp_command_refresh_done"]))

--- a/Commands.cs
+++ b/Commands.cs
@@ -587,7 +587,7 @@ namespace WeaponPaints
 
 				var selectedPaintName = option.Text;
 
-				var selectedMusic = musicList.FirstOrDefault(g => g.ContainsKey("name") && g["name"]?.ToString() == selectedPaintName);
+				var selectedMusic = musicList.FirstOrDefault(g => g.ContainsKey("name") && g["name"]?.ToString().Contains(selectedPaintName) == true);
 				if (selectedMusic != null)
 				{
 					if (!selectedMusic.ContainsKey("id") ||
@@ -621,7 +621,7 @@ namespace WeaponPaints
 
 					if (!string.IsNullOrEmpty(Localizer["wp_music_menu_select"]))
 					{
-						player!.Print(Localizer["wp_music_menu_select", selectedPaintName]);
+						player!.Print(Localizer["wp_music_menu_select", selectedMusic["name"] ?? selectedPaintName]);
 					}
 
 					if (weaponSync != null)
@@ -661,6 +661,8 @@ namespace WeaponPaints
 						});
 					}
 				}
+
+				GivePlayerMusicKit(player);
 			};
 
 			musicSelectionMenu.AddMenuOption(Localizer["None"], handleMusicSelection);

--- a/Commands.cs
+++ b/Commands.cs
@@ -474,7 +474,7 @@ namespace WeaponPaints
 				var selectedPaintName = option.Text;
 				var selectedAgent = agentsList.FirstOrDefault(g =>
 					g.ContainsKey("agent_name") &&
-					g["agent_name"] != null && g["agent_name"]!.ToString() == selectedPaintName &&
+					g["agent_name"] != null && g["agent_name"]!.ToString().Contains(selectedPaintName) == true &&
 					g["team"] != null && (int)(g["team"]!) == player.TeamNum);
 
 				if (selectedAgent == null) return;
@@ -502,7 +502,7 @@ namespace WeaponPaints
 
 					if (!string.IsNullOrEmpty(Localizer["wp_agent_menu_select"]))
 					{
-						player!.Print(Localizer["wp_agent_menu_select", selectedPaintName]);
+						player!.Print(Localizer["wp_agent_menu_select", selectedAgent?["agent_name"] ?? selectedPaintName]);
 					}
 
 					if (player.TeamNum == 3)
@@ -524,6 +524,7 @@ namespace WeaponPaints
 						_ = Task.Run(async () =>
 						{
 							await weaponSync.SyncAgentToDatabase(playerInfo);
+							GivePlayerAgent(player);
 						});
 					}
 				};

--- a/Commands.cs
+++ b/Commands.cs
@@ -38,6 +38,8 @@ namespace WeaponPaints
 						_ = Task.Run(async () => await weaponSync.GetPlayerData(playerInfo));
 
 						GivePlayerGloves(player);
+						GivePlayerAgent(player);
+						GivePlayerMusicKit(player);
 						RefreshWeapons(player);
 					}
 

--- a/Commands.cs
+++ b/Commands.cs
@@ -11,7 +11,7 @@ namespace WeaponPaints
 	{
 		private void OnCommandRefresh(CCSPlayerController? player, CommandInfo command)
 		{
-			if (Config.Additional.CommandsRefresh.Count > 0 || !Config.Additional.SkinEnabled || !g_bCommandsAllowed) return;
+			if (Config.Additional.CommandsRefresh.Count == 0 || !Config.Additional.SkinEnabled || !g_bCommandsAllowed) return;
 			if (!Utility.IsPlayerValid(player)) return;
 
 			if (player == null || !player.IsValid || player.UserId == null || player.IsBot) return;

--- a/Config.cs
+++ b/Config.cs
@@ -41,6 +41,9 @@ namespace WeaponPaints
         [JsonPropertyName("NameTagEnabled")]
         public bool NameTagEnabled { get; set; } = true;
 
+		[JsonPropertyName("PinEnabled")]
+		public bool PinEnabled { get; set; } = true;
+
 		[JsonPropertyName("CommandsKnife")]
 		public List<string> CommandsKnife { get; set; } = ["knife", "knives"];
 

--- a/Events.cs
+++ b/Events.cs
@@ -1,4 +1,4 @@
-﻿using CounterStrikeSharp.API;
+using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Core.Attributes.Registration;
 using CounterStrikeSharp.API.Modules.Entities;
@@ -91,6 +91,10 @@ namespace WeaponPaints
 			{
 				g_playersMusic.TryRemove(player.Slot, out _);
 			}
+			if (Config.Additional.PinEnabled)
+			{
+				g_playersPin.TryRemove(player.Slot, out _);
+			}
 
 			commandsCooldown.Remove(player.Slot);
 
@@ -125,6 +129,7 @@ namespace WeaponPaints
 			GivePlayerMusicKit(player);
 			GivePlayerAgent(player);
 			GivePlayerGloves(player);
+			GivePlayerPin(player);
 
 			return HookResult.Continue;
 		}

--- a/Utility.cs
+++ b/Utility.cs
@@ -1,4 +1,4 @@
-﻿using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Core.Translations;
 using Dapper;
 using Microsoft.Extensions.Logging;
@@ -30,7 +30,8 @@ namespace WeaponPaints
                         "CREATE TABLE IF NOT EXISTS `wp_users_knives` (`user_id` INT UNSIGNED NOT NULL, `knife` SMALLINT UNSIGNED NOT NULL, PRIMARY KEY (`user_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
                         "CREATE TABLE IF NOT EXISTS `wp_users_gloves` (`user_id` INT UNSIGNED NOT NULL, `weapon_defindex` SMALLINT UNSIGNED DEFAULT NULL, PRIMARY KEY (`user_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
                         "CREATE TABLE IF NOT EXISTS `wp_users_musics` (`user_id` INT UNSIGNED NOT NULL, `music` SMALLINT UNSIGNED DEFAULT NULL, PRIMARY KEY (`user_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
-                        "CREATE TABLE IF NOT EXISTS `wp_users_agents` (`user_id` INT UNSIGNED NOT NULL,`agent_ct` varchar(64) DEFAULT NULL,`agent_t` varchar(64) DEFAULT NULL, PRIMARY KEY (`user_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;"
+                        "CREATE TABLE IF NOT EXISTS `wp_users_agents` (`user_id` INT UNSIGNED NOT NULL,`agent_ct` varchar(64) DEFAULT NULL,`agent_t` varchar(64) DEFAULT NULL, PRIMARY KEY (`user_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
+                        "CREATE TABLE IF NOT EXISTS `wp_users_pins` (`user_id` INT UNSIGNED NOT NULL, `pin` SMALLINT UNSIGNED DEFAULT NULL, PRIMARY KEY (`user_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;",
                     };
 
 					foreach (var query in createTableQueries)

--- a/WeaponAction.cs
+++ b/WeaponAction.cs
@@ -401,6 +401,18 @@ public partial class WeaponPaints
         Utilities.SetStateChanged(player, "CCSPlayerController", "m_iMusicKitID");
     }
 
+    private static void GivePlayerPin(CCSPlayerController player)
+    {
+        if (!g_playersPin.TryGetValue(player.Slot, out var value)) return;
+        if (player.InventoryServices == null) return;
+
+        for (var index = 0; index < player.InventoryServices.Rank.Length; index++)
+        {
+            player.InventoryServices.Rank[index] = index == 5 ? (MedalRank_t)value : MedalRank_t.MEDAL_RANK_NONE;
+            Utilities.SetStateChanged(player, "CCSPlayerController", "m_pInventoryServices");
+        }
+    }
+
     private void GiveOnItemPickup(CCSPlayerController player)
     {
         var pawn = player.PlayerPawn.Value;

--- a/WeaponPaints.cs
+++ b/WeaponPaints.cs
@@ -83,6 +83,7 @@ public partial class WeaponPaints : BasePlugin, IPluginConfig<WeaponPaintsConfig
 	internal static ConcurrentDictionary<int, ushort> g_playersKnife = new();
 	internal static ConcurrentDictionary<int, ushort> g_playersGlove = new();
 	internal static ConcurrentDictionary<int, ushort> g_playersMusic = new();
+	internal static ConcurrentDictionary<int, ushort> g_playersPin = new();
 	internal static ConcurrentDictionary<int, (string? CT, string? T)> g_playersAgent = new();
 	internal static ConcurrentDictionary<int, ConcurrentDictionary<ushort, WeaponInfo>> gPlayerWeaponsInfo = new();
     internal static ConcurrentDictionary<int, int> g_playersDatabaseIndex = new();


### PR DESCRIPTION
- Fixed some database queries.
- Fixed `!wp` refresh command conditions, `Config.Additional.CommandsRefresh.Count > 0` is always true and blocking refresh if you have commands configured.
- `!wp` should also refresh music and agents, because some websites have music and agents and feature.
- Added pin feature, codes taken from [cs2-inventory-simulator](https://github.com/ianlucas/cs2-inventory-simulator-plugin/blob/2cf5d489fa44f30f97e45ba08188ed3ac3f0d413/source/InventorySimulator/InventorySimulator.Give.cs#L31-L43), **only functions and databases, menu and json are not included in this PR**.
- Fixed music kits and agents menu.
  (Music kit names and agent names are too long for CenterHtmlMenu, it's impossible to use `==` to find selected item,)