### PR TITLE
feat: Stickers and Charms

### DIFF
--- a/Events.cs
+++ b/Events.cs
@@ -89,6 +89,8 @@ namespace WeaponPaints
 				g_playersMusic.TryRemove(player.Slot, out _);
 			}
 
+			temporaryPlayerWeaponWear.TryRemove(player.Slot, out _);
+
 			commandsCooldown.Remove(player.Slot);
 
 			return HookResult.Continue;

--- a/Utility.cs
+++ b/Utility.cs
@@ -31,7 +31,14 @@ namespace WeaponPaints
 						                        `weapon_defindex` int(6) NOT NULL,
 						                        `weapon_paint_id` int(6) NOT NULL,
 						                        `weapon_wear` float NOT NULL DEFAULT 0.000001,
-						                        `weapon_seed` int(16) NOT NULL DEFAULT 0
+						                        `weapon_seed` int(16) NOT NULL DEFAULT 0,
+												`weapon_nametag` VARCHAR(128) DEFAULT NULL,
+												`weapon_sticker_0` VARCHAR(128) NOT NULL DEFAULT '0;0;0;0;0;0;0' COMMENT 'id;schema;x;y;wear;scale;rotation',
+												`weapon_sticker_1` VARCHAR(128) NOT NULL DEFAULT '0;0;0;0;0;0;0' COMMENT 'id;schema;x;y;wear;scale;rotation',
+												`weapon_sticker_2` VARCHAR(128) NOT NULL DEFAULT '0;0;0;0;0;0;0' COMMENT 'id;schema;x;y;wear;scale;rotation',
+												`weapon_sticker_3` VARCHAR(128) NOT NULL DEFAULT '0;0;0;0;0;0;0' COMMENT 'id;schema;x;y;wear;scale;rotation',
+												`weapon_sticker_4` VARCHAR(128) NOT NULL DEFAULT '0;0;0;0;0;0;0' COMMENT 'id;schema;x;y;wear;scale;rotation',
+												`weapon_keychain`VARCHAR(128) NOT NULL DEFAULT '0;0;0;0;0' COMMENT 'id;x;y;z;seed'
 						                    ) ENGINE=InnoDB
 						""",
 						@"CREATE TABLE IF NOT EXISTS `wp_player_knife` (

--- a/WeaponInfo.cs
+++ b/WeaponInfo.cs
@@ -1,29 +1,32 @@
-﻿public class WeaponInfo
+﻿namespace WeaponPaints
 {
-	public int Paint { get; set; }
-	public int Seed { get; set; } = 0;
-	public float Wear { get; set; } = 0f;
-	public string Nametag { get; set; } = "";
-	public KeyChainInfo? KeyChain { get; set; }
-	public List<StickerInfo> Stickers { get; set; } = new List<StickerInfo>();
-}
+	public class WeaponInfo
+	{
+		public int Paint { get; set; }
+		public int Seed { get; set; } = 0;
+		public float Wear { get; set; } = 0f;
+		public string Nametag { get; set; } = "";
+		public KeyChainInfo? KeyChain { get; set; }
+		public List<StickerInfo> Stickers { get; set; } = new List<StickerInfo>();
+	}
 
-public class StickerInfo
-{
-	public uint Id { get; set; }
-	public uint Schema { get; set; }
-	public float OffsetX { get; set; }
-	public float OffsetY { get; set; }
-	public float Wear { get; set; }
-	public float Scale { get; set; }
-	public float Rotation { get; set; }
-}
+	public class StickerInfo
+	{
+		public uint Id { get; set; }
+		public uint Schema { get; set; }
+		public float OffsetX { get; set; }
+		public float OffsetY { get; set; }
+		public float Wear { get; set; }
+		public float Scale { get; set; }
+		public float Rotation { get; set; }
+	}
 
-public class KeyChainInfo
-{
-	public uint Id { get; set; }
-	public float OffsetX { get; set; }
-	public float OffsetY { get; set; }
-	public float OffsetZ { get; set; }
-	public uint Seed { get; set; }
+	public class KeyChainInfo
+	{
+		public uint Id { get; set; }
+		public float OffsetX { get; set; }
+		public float OffsetY { get; set; }
+		public float OffsetZ { get; set; }
+		public uint Seed { get; set; }
+	}
 }

--- a/WeaponInfo.cs
+++ b/WeaponInfo.cs
@@ -1,9 +1,29 @@
-﻿namespace WeaponPaints
+﻿public class WeaponInfo
 {
-	public class WeaponInfo
-	{
-		public int Paint { get; set; }
-		public int Seed { get; set; } = 0;
-		public float Wear { get; set; } = 0f;
-	}
+	public int Paint { get; set; }
+	public int Seed { get; set; } = 0;
+	public float Wear { get; set; } = 0f;
+	public string Nametag { get; set; } = "";
+	public KeyChainInfo? KeyChain { get; set; }
+	public List<StickerInfo> Stickers { get; set; } = new List<StickerInfo>();
+}
+
+public class StickerInfo
+{
+	public uint Id { get; set; }
+	public uint Schema { get; set; }
+	public float OffsetX { get; set; }
+	public float OffsetY { get; set; }
+	public float Wear { get; set; }
+	public float Scale { get; set; }
+	public float Rotation { get; set; }
+}
+
+public class KeyChainInfo
+{
+	public uint Id { get; set; }
+	public float OffsetX { get; set; }
+	public float OffsetY { get; set; }
+	public float OffsetZ { get; set; }
+	public uint Seed { get; set; }
 }

--- a/WeaponPaints.cs
+++ b/WeaponPaints.cs
@@ -165,6 +165,8 @@ public partial class WeaponPaints : BasePlugin, IPluginConfig<WeaponPaintsConfig
 	private ulong _nextItemId = MinimumCustomItemId;
 	public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
+	private ConcurrentDictionary<int, ConcurrentDictionary<int, float>> temporaryPlayerWeaponWear = new ConcurrentDictionary<int, ConcurrentDictionary<int, float>>();
+
 	public WeaponPaintsConfig Config { get; set; } = new();
 	public override string ModuleAuthor => "Nereziel & daffyy";
 	public override string ModuleDescription => "Skin, gloves, agents and knife selector, standalone and web-based";

--- a/WeaponPaints.csproj
+++ b/WeaponPaints.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.233" />
+    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.281" />
     <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="MySqlConnector" Version="2.3.7" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
# Stickers and Charms

- Added the possibility to apply stickers to weapons.
- Added the possibility to attach charms to weapons.
- Added the possibility to add nametags to weapons/knives.
- Stickers and charms update after using the `!wp` refresh command, which reloads the player's weapon data.

> [!IMPORTANT] 
This update does not include functionality to modify stickers and charms directly from the server. This functionality must be implemented via skin sites.

> [!WARNING] 
If you are already using weapon paints and want to upgrade to this version, run the following query in your database:

```sql
ALTER TABLE wp_player_skins
ADD COLUMN weapon_nametag VARCHAR(128) DEFAULT NULL,
ADD COLUMN weapon_sticker_0 VARCHAR(128) DEFAULT '0;0;0;0;0;0;0' COMMENT 'id;schema;x;y;wear;scale;rotation',
ADD COLUMN weapon_sticker_1 VARCHAR(128) DEFAULT '0;0;0;0;0;0;0' COMMENT 'id;schema;x;y;wear;scale;rotation',
ADD COLUMN weapon_sticker_2 VARCHAR(128) DEFAULT '0;0;0;0;0;0;0' COMMENT 'id;schema;x;y;wear;scale;rotation',
ADD COLUMN weapon_sticker_3 VARCHAR(128) DEFAULT '0;0;0;0;0;0;0' COMMENT 'id;schema;x;y;wear;scale;rotation',
ADD COLUMN weapon_sticker_4 VARCHAR(128) DEFAULT '0;0;0;0;0;0;0' COMMENT 'id;schema;x;y;wear;scale;rotation',
ADD COLUMN weapon_keychain VARCHAR(128) DEFAULT '0;0;0;0;0' COMMENT 'id;x;y;z;seed';
