### PR TITLE
Add sealed dead hand terminal skins and gloves

### DIFF
--- a/website/data/gloves_bg.json
+++ b/website/data/gloves_bg.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "★ Шофьорски ръкавици | Лунно вплитане"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "★ Специализирани ръкавици | Горска разпокъсана цифрова шарка"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "★ Специализирани ръкавици | Монголско"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_cs.json
+++ b/website/data/gloves_cs.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "Řidičské rukavice (★) | Lunar Weave"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "Profesionální rukavice (★) | Forest DDPAT"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "Profesionální rukavice (★) | Mogul"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_da.json
+++ b/website/data/gloves_da.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "Kørehandsker (★) | Lunar Weave"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "Specialisthandsker (★) | Forest DDPAT"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "Specialisthandsker (★) | Mogul"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_de.json
+++ b/website/data/gloves_de.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "Chauffeurshandschuhe (★) | Mondgewebe"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "Spezialistenhandschuhe (★) | Wald-DDPAT"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "Spezialistenhandschuhe (★) | Mogul"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_el.json
+++ b/website/data/gloves_el.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "★ Γάντια οδηγού | Lunar Weave"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "★ Γάντια ειδικού | Forest DDPAT"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "★ Γάντια ειδικού | Mogul"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_en.json
+++ b/website/data/gloves_en.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "★ Driver Gloves | Lunar Weave"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "★ Specialist Gloves | Forest DDPAT"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "★ Specialist Gloves | Mogul"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_es-ES.json
+++ b/website/data/gloves_es-ES.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "Guantes de conductor ★ | Entrelazado lunar"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "Guantes de especialista ★ | DDPAT boscoso"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "Guantes de especialista ★ | Mogul"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_es-MX.json
+++ b/website/data/gloves_es-MX.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "Guantes de conductor ★ | Entrelazado lunar"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "Guantes de especialista ★ | DDPAT de bosque"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "Guantes de especialista ★ | Mogul"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_fi.json
+++ b/website/data/gloves_fi.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "★ Ajohanskat | Kuukudos"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "★ Ammattilaishanskat | Kesämaasto"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "★ Ammattilaishanskat | Moguli"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_fr.json
+++ b/website/data/gloves_fr.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "Gants de pilote (★) | Tissage lunaire"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "Gants de spécialiste (★) | Tempéré numérique"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "Gants de spécialiste (★) | Moghol"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_hu.json
+++ b/website/data/gloves_hu.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "Sofőrkesztyű (★) | Hold-szövet"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "Specialista kesztyűk (★) | Erdei DDPAT"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "Specialista kesztyűk (★) | Mogul"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_it.json
+++ b/website/data/gloves_it.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "Guanti da autista ★ | Lunar Weave"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "Guanti dello specialista ★ | Forest DDPAT"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "Guanti dello specialista ★ | Mogul"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_ja.json
+++ b/website/data/gloves_ja.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "★ Driver Gloves | Lunar Weave"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "★ Specialist Gloves | Forest DDPAT"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "★ Specialist Gloves | Mogul"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_ko.json
+++ b/website/data/gloves_ko.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "★ 운전용 장갑 | 달빛 직조"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "★ 전문가 장갑 | 숲 디지털 위장"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "★ 전문가 장갑 | 모글"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_nl.json
+++ b/website/data/gloves_nl.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "★ Rijhandschoenen | Lunar Weave"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "★ Specialisthandschoenen | Forest DDPAT"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "★ Specialisthandschoenen | Mogul"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_no.json
+++ b/website/data/gloves_no.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "Kjørehansker (★) | Lunar Weave"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "Spesialisthansker (★) | Forest DDPAT"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "Spesialisthansker (★) | Mogul"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_pl.json
+++ b/website/data/gloves_pl.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "Rękawiczki samochodowe (★) | Splot księżycowy"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "Rękawice specjalistyczne (★) | Leśny DDPAT"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "Rękawice specjalistyczne (★) | Mulda"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_pt-BR.json
+++ b/website/data/gloves_pt-BR.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "Luvas de Motorista ★ | Entrelaçamento Lunar"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "Luvas de Especialista ★ | Camuflagem Digital — Floresta"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "Luvas de Especialista ★ | Mogul"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_pt-PT.json
+++ b/website/data/gloves_pt-PT.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "Luvas de Condutor ★ | Lunar Weave"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "Luvas de Especialista ★ | Forest DDPAT"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "Luvas de Especialista ★ | Mogul"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_ro.json
+++ b/website/data/gloves_ro.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "Mănuși de condus (★) | Țesătură selenică"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "Mănuși de specialist (★) | Forest DDPAT"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "Mănuși de specialist (★) | Mogul"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_ru.json
+++ b/website/data/gloves_ru.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "★ Водительские перчатки | Лунный узор"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "★ Перчатки спецназа | Пиксельный камуфляж «Лес»"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "★ Перчатки спецназа | Покоритель гор"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_sv.json
+++ b/website/data/gloves_sv.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "★ Förarhandskar | Lunar Weave"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "★ Specialisthandskar | Forest DDPAT"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "★ Specialisthandskar | Mogul"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_th.json
+++ b/website/data/gloves_th.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "ถุงมือขับรถ (★) | Lunar Weave"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "ถุงมือผู้เชี่ยวชาญ (★) | Forest DDPAT"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "ถุงมือผู้เชี่ยวชาญ (★) | Mogul"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_tr.json
+++ b/website/data/gloves_tr.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "★ Sürücü Eldivenleri | Gümüş Örgü"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "★ Uzman Eldivenleri | Orman DDPAT"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "★ Uzman Eldivenleri | Mogul"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_uk.json
+++ b/website/data/gloves_uk.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "Рукавиці водія (★) | Місячний візерунок"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "Рукавиці спеціаліста (★) | Пікс. камуфляж «Ліс»"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "Рукавиці спеціаліста (★) | Могул"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_vi.json
+++ b/website/data/gloves_vi.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "Găng tay lái xe (★) | Lunar Weave"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "Găng tay chuyên viên (★) | Forest DDPAT"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "Găng tay chuyên viên (★) | Mogul"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_zh-CN.json
+++ b/website/data/gloves_zh-CN.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "驾驶手套（★） | 月色织物"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "专业手套（★） | 森林 DDPAT"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "专业手套（★） | 大腕"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/gloves_zh-TW.json
+++ b/website/data/gloves_zh-TW.json
@@ -151,6 +151,54 @@
     },
     {
         "weapon_defindex": 5031,
+        "paint": "1398",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1398.png",
+        "paint_name": "★ Driver Gloves | Wave Chaser"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1404",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1404.png",
+        "paint_name": "★ Driver Gloves | Seigaiha"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1412",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1412.png",
+        "paint_name": "★ Driver Gloves | Plum Quill"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1439",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1439.png",
+        "paint_name": "★ Driver Gloves | Hand Sweaters"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1402",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1402.png",
+        "paint_name": "★ Driver Gloves | Garden"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1401",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1401.png",
+        "paint_name": "★ Driver Gloves | Dragon Fists"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1400",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1400.png",
+        "paint_name": "★ Driver Gloves | Brocade Flowers"
+    },
+    {
+        "weapon_defindex": 5031,
+        "paint": "1399",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-1399.png",
+        "paint_name": "★ Driver Gloves | Brocade Crane"
+    },
+    {
+        "weapon_defindex": 5031,
         "paint": "10013",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/slick_gloves-10013.png",
         "paint_name": "★ 駕駛手套 | 靛藍編織"
@@ -223,6 +271,48 @@
     },
     {
         "weapon_defindex": 5034,
+        "paint": "1416",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1416.png",
+        "paint_name": "★ Specialist Gloves | Sunburst"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1438",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1438.png",
+        "paint_name": "★ Specialist Gloves | Pillow Punchers"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1413",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1413.png",
+        "paint_name": "★ Specialist Gloves | Lime Polycam"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1440",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1440.png",
+        "paint_name": "★ Specialist Gloves | Cloud Chaser"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1415",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1415.png",
+        "paint_name": "★ Specialist Gloves | Chocolate Chesterfield"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1414",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1414.png",
+        "paint_name": "★ Specialist Gloves | Blackbook"
+    },
+    {
+        "weapon_defindex": 5034,
+        "paint": "1437",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-1437.png",
+        "paint_name": "★ Specialist Gloves | Big Swell"
+    },
+    {
+        "weapon_defindex": 5034,
         "paint": "10030",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10030.png",
         "paint_name": "★ 技術士手套 | 森林數位迷彩"
@@ -292,6 +382,48 @@
         "paint": "10064",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/specialist_gloves-10064.png",
         "paint_name": "★ 技術士手套 | 雪丘"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1405",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1405.png",
+        "paint_name": "★ Sport Gloves | Violet Beadwork"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1410",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1410.png",
+        "paint_name": "★ Sport Gloves | Ultra Violent"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1409",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1409.png",
+        "paint_name": "★ Sport Gloves | Red Racer"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1417",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1417.png",
+        "paint_name": "★ Sport Gloves | Occult"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1406",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1406.png",
+        "paint_name": "★ Sport Gloves | Frosty"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1408",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1408.png",
+        "paint_name": "★ Sport Gloves | Creme Pinstripe"
+    },
+    {
+        "weapon_defindex": 5030,
+        "paint": "1407",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/sporty_gloves-1407.png",
+        "paint_name": "★ Sport Gloves | Blaze"
     },
     {
         "weapon_defindex": 5030,

--- a/website/data/skins_bg.json
+++ b/website/data/skins_bg.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Изпепеляваща ярост",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Избледняване",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Табло с прекъсвачи",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Боровинки и череши",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Избледняващ кехлибар",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Ацтек",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Избледняване",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Нивга вече",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Скъсена цев  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Механизъм",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_cs.json
+++ b/website/data/skins_cs.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Searing Rage",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Fade",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Breaker Box",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Berries And Cherries",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Amber Fade",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Aztec",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Fade",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Nevermore",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Upilovaná brokovnice  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Mechanism",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_da.json
+++ b/website/data/skins_da.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Searing Rage",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Fade",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Breaker Box",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Berries And Cherries",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Amber Fade",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Aztec",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Fade",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Nevermore",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Sawed-off  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Mechanism",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_de.json
+++ b/website/data/skins_de.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Lodernder Zorn",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Farbverlauf",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Unterbrecherkasten",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Beeren und Kirschen",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Bernsteinfärbung",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Aztec",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Farbverlauf",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Nimmermehr",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Abgesägte Schrotflinte  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Mechanismus",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_el.json
+++ b/website/data/skins_el.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Searing Rage",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Fade",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Breaker Box",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Berries And Cherries",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Amber Fade",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Aztec",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Fade",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Nevermore",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Sawed-Off  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Mechanism",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_en.json
+++ b/website/data/skins_en.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Searing Rage",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Fade",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Breaker Box",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Berries And Cherries",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Amber Fade",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Aztec",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Fade",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Nevermore",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Sawed-Off  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Mechanism",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_es-ES.json
+++ b/website/data/skins_es-ES.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Furia ardiente",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Desteñido",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Caja de fusibles",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-seveN | Bayas y cerezas",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Ámbar desteñido",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Azteca",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Descolorido",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Nunca más",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Recortada  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Mecanismo",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_es-MX.json
+++ b/website/data/skins_es-MX.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Furia abrasadora",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Desteñido",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Caja de fusibles",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Bayas y cerezas",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Ámbar desteñido",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Azteca",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Desteñido",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Nunca más",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Recortada  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Mecanismo",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_fi.json
+++ b/website/data/skins_fi.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Vihan kyllästämä",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Häivytys",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Sulaketaulu",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Mustikat ja mansikat",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Himmeä meripihka",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Aztec",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Häivytys",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Nevermore",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Katkaistu haulikko  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Koneisto",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_fr.json
+++ b/website/data/skins_fr.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Rage inextinguible",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Dégradé",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Disjoncteur",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Gyrophares",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Dégradé ambré",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Aztèque",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Dégradé",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Jamais plus",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Sawed-Off  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Mécanisme",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_hu.json
+++ b/website/data/skins_hu.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Perzselő Düh",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Halványulás",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Kapcsolószekrény",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Bogyók és Cseresznyék",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Halvány Borostyán",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Azték",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Halványulás",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Sohamár",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Lefűrészelt csövű sörétes  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Gépezet",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_it.json
+++ b/website/data/skins_it.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Searing Rage",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Fade",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Breaker Box",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Berries And Cherries",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Amber Fade",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Aztec",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Fade",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Nevermore",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Fucile a canne mozze  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Mechanism",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_ja.json
+++ b/website/data/skins_ja.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Searing Rage",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Fade",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Breaker Box",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Berries And Cherries",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Amber Fade",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Aztec",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Fade",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Nevermore",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Sawed-Off  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Mechanism",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_ko.json
+++ b/website/data/skins_ko.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | 타오르는 분노",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | 흐릿함",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP 비존 | 두꺼비집",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "데저트 이글  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "파이브 세븐 | 딸기와 체리",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "갈릴 돌격소총 | 호박빛 배색",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "글록 18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | 아즈텍",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | 페이드",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | 네버모어",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "소드오프  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | 기계 공학",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_nl.json
+++ b/website/data/skins_nl.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Searing Rage",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Fade",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Breaker Box",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Berries And Cherries",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Amber Fade",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Aztec",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Fade",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Nevermore",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Sawed-Off  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Mechanism",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_no.json
+++ b/website/data/skins_no.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Searing Rage",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Fade",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Breaker Box",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Berries And Cherries",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Amber Fade",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Aztec",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Fade",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Nevermore",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Sawed-Off  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Mechanism",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_pl.json
+++ b/website/data/skins_pl.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Paląca furia",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Gradient",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Skrzynka na bezpieczniki",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Kogut",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Spłowiały bursztyn",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Aztec",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Gradient",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Kres i krach",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Obrzyn  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Mechanizm",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_pt-BR.json
+++ b/website/data/skins_pt-BR.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Fúria Ardente",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Degradê",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Disjuntor",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Os Homi",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Âmbar",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Aztec",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Degradê",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Nunca Mais",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Cano Curto  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Mecanismo",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_pt-PT.json
+++ b/website/data/skins_pt-PT.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Searing Rage",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Fade",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Breaker Box",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Berries And Cherries",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Amber Fade",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Aztec",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Fade",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Nevermore",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Sawed-Off  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Mechanism",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_ro.json
+++ b/website/data/skins_ro.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Searing Rage",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Fade",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Breaker Box",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Berries And Cherries",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Amber Fade",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Aztec",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Fade",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Nevermore",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Sawed-Off  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Mechanism",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_ru.json
+++ b/website/data/skins_ru.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Жгучая ярость",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Градиент",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "ПП-19 «Бизон» | Электрощиток",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Мигалка",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Автомат «Галиль» | Янтарный градиент",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Ацтекские мотивы",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Градиент",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Ворон",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Обрез  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Механизм",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_sv.json
+++ b/website/data/skins_sv.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Searing Rage",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Fade",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Breaker Box",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Berries And Cherries",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Amber Fade",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Aztec",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Fade",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Nevermore",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Sawed-Off  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Mechanism",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_th.json
+++ b/website/data/skins_th.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Searing Rage",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Fade",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Breaker Box",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Berries And Cherries",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Amber Fade",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Aztec",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Fade",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Nevermore",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Sawed-Off  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Mechanism",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_tr.json
+++ b/website/data/skins_tr.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Kavurucu Öfke",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Solgun",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Sigorta Kutusu",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Aynasızlar",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Solgun Sarı",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Aztec",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Solgun",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Nevermore",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Sawed-Off  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Mekanizma",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_uk.json
+++ b/website/data/skins_uk.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "АК-47 | Палюча лють",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "АВП | Градієнт",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "ПП «Бізон» | Електрощит",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Пустельний орел  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-seveN | Ягоди та вишні",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Ґаліл | Бурштиновий градієнт",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Ґлок-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "М249 | Ацтек",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "М4А4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "М4А1-С  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "МП7 | Градієнт",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "МП9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "П250 | Крук",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "П90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Обріз  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "УМП-45 | Механізм",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "УСП-С  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_vi.json
+++ b/website/data/skins_vi.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | Searing Rage",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | Fade",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | Breaker Box",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | Berries And Cherries",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | Amber Fade",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | Aztec",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | Fade",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | Nevermore",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Súng nòng ngắn  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | Mechanism",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_zh-CN.json
+++ b/website/data/skins_zh-CN.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | 灼心怒焰",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | 渐变之色",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-野牛 | 开关箱",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "沙漠之鹰  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "FN57 | 蓝莓樱桃",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "加利尔AR | 渐变琥珀",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "格洛克18型  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | 阿兹特克",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1消音版  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | 渐变之色",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | 影魔",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "截短霰弹枪  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | 机械装置",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP消音版  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {

--- a/website/data/skins_zh-TW.json
+++ b/website/data/skins_zh-TW.json
@@ -10,6 +10,14 @@
     {
         "weapon_defindex": 7,
         "weapon_name": "weapon_ak47",
+        "paint": "1425",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1425.png",
+        "paint_name": "AK-47 | Crane Flight",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 7,
+        "weapon_name": "weapon_ak47",
         "paint": "1207",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ak47-1207.png",
         "paint_name": "AK-47 | 燃燒怒火",
@@ -842,6 +850,14 @@
     {
         "weapon_defindex": 9,
         "weapon_name": "weapon_awp",
+        "paint": "1422",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1422.png",
+        "paint_name": "AWP | Queen's Gambit",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 9,
+        "weapon_name": "weapon_awp",
         "paint": "1026",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_awp-1026.png",
         "paint_name": "AWP | 漸層彩虹",
@@ -1522,6 +1538,14 @@
     {
         "weapon_defindex": 26,
         "weapon_name": "weapon_bizon",
+        "paint": "1418",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1418.png",
+        "paint_name": "PP-Bizon | RMX",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 26,
+        "weapon_name": "weapon_bizon",
         "paint": "1083",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_bizon-1083.png",
         "paint_name": "PP-Bizon | 配電箱",
@@ -2117,6 +2141,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle.png",
         "paint_name": "Desert Eagle  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 1,
+        "weapon_name": "weapon_deagle",
+        "paint": "1430",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_deagle-1430.png",
+        "paint_name": "Desert Eagle | Firebreathing",
         "legacy_model": false
     },
     {
@@ -3162,6 +3194,14 @@
     {
         "weapon_defindex": 3,
         "weapon_name": "weapon_fiveseven",
+        "paint": "1429",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1429.png",
+        "paint_name": "Five-SeveN | Dark Polymer",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 3,
+        "weapon_name": "weapon_fiveseven",
         "paint": "1002",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_fiveseven-1002.png",
         "paint_name": "Five-SeveN | 莓果櫻桃",
@@ -3738,6 +3778,14 @@
     {
         "weapon_defindex": 13,
         "weapon_name": "weapon_galilar",
+        "paint": "1434",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-1434.png",
+        "paint_name": "Galil AR | Galigator",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 13,
+        "weapon_name": "weapon_galilar",
         "paint": "246",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_galilar-246.png",
         "paint_name": "Galil AR | 琥珀漸層",
@@ -4085,6 +4133,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock.png",
         "paint_name": "Glock-18  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 4,
+        "weapon_name": "weapon_glock",
+        "paint": "1421",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_glock-1421.png",
+        "paint_name": "Glock-18 | Fully Tuned",
         "legacy_model": false
     },
     {
@@ -9170,6 +9226,14 @@
     {
         "weapon_defindex": 14,
         "weapon_name": "weapon_m249",
+        "paint": "1435",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-1435.png",
+        "paint_name": "M249 | Bock Blocks",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 14,
+        "weapon_name": "weapon_m249",
         "paint": "902",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m249-902.png",
         "paint_name": "M249 | 阿茲特克 Aztec",
@@ -9373,6 +9437,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1.png",
         "paint_name": "M4A4  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 16,
+        "weapon_name": "weapon_m4a1",
+        "paint": "1432",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1-1432.png",
+        "paint_name": "M4A4 | Zubastick",
         "legacy_model": false
     },
     {
@@ -9717,6 +9789,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer.png",
         "paint_name": "M4A1-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 60,
+        "weapon_name": "weapon_m4a1_silencer",
+        "paint": "1433",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_m4a1_silencer-1433.png",
+        "paint_name": "M4A1-S | Electrum",
         "legacy_model": false
     },
     {
@@ -11090,6 +11170,14 @@
     {
         "weapon_defindex": 33,
         "weapon_name": "weapon_mp7",
+        "paint": "1436",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-1436.png",
+        "paint_name": "MP7 | Amberline",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 33,
+        "weapon_name": "weapon_mp7",
         "paint": "752",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp7-752.png",
         "paint_name": "MP7 | 漸層",
@@ -11397,6 +11485,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9.png",
         "paint_name": "MP9  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 34,
+        "weapon_name": "weapon_mp9",
+        "paint": "1423",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_mp9-1423.png",
+        "paint_name": "MP9 | Urban Sovereign",
         "legacy_model": false
     },
     {
@@ -12338,6 +12434,14 @@
     {
         "weapon_defindex": 36,
         "weapon_name": "weapon_p250",
+        "paint": "1420",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-1420.png",
+        "paint_name": "P250 | Kintsugi",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 36,
+        "weapon_name": "weapon_p250",
         "paint": "813",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p250-813.png",
         "paint_name": "P250 | 往事不復矣",
@@ -12789,6 +12893,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90.png",
         "paint_name": "P90  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 19,
+        "weapon_name": "weapon_p90",
+        "paint": "1419",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_p90-1419.png",
+        "paint_name": "P90 | Deathgaze",
         "legacy_model": false
     },
     {
@@ -13421,6 +13533,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff.png",
         "paint_name": "Sawed-Off  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 29,
+        "weapon_name": "weapon_sawedoff",
+        "paint": "1427",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_sawedoff-1427.png",
+        "paint_name": "Sawed-Off | Fusion",
         "legacy_model": false
     },
     {
@@ -15066,6 +15186,14 @@
     {
         "weapon_defindex": 24,
         "weapon_name": "weapon_ump45",
+        "paint": "1426",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1426.png",
+        "paint_name": "UMP-45 | Fragment",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 24,
+        "weapon_name": "weapon_ump45",
         "paint": "1085",
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_ump45-1085.png",
         "paint_name": "UMP-45 | 機關",
@@ -15421,6 +15549,14 @@
         "paint": 0,
         "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer.png",
         "paint_name": "USP-S  | Default",
+        "legacy_model": false
+    },
+    {
+        "weapon_defindex": 61,
+        "weapon_name": "weapon_usp_silencer",
+        "paint": "1431",
+        "image": "https://raw.githubusercontent.com/Nereziel/cs2-WeaponPaints/main/website/img/skins/weapon_usp_silencer-1431.png",
+        "paint_name": "USP-S | Silent Shot",
         "legacy_model": false
     },
     {


### PR DESCRIPTION
Added Sealed Dead Hand Terminal skins and gloves based on latest CS2 data.

- Weapon skins are placed after their respective Default entries
- Gloves are grouped by type with new finishes placed at the top of each group
- Maintains consistency with existing structure