### PR TITLE
docs: list community web panels in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ Unfinished, unoptimized and not fully functional ugly demo weapon paints plugin 
 - Steam login/logout
 - Change knife, paint, seed and wear
 
+## Alternative web panels (community)
+The bundled PHP site under `website/` is the minimal reference UI. Community-maintained frontends that talk to the same database and add extra features:
+
+- **[cs2-weaponpaints-website (Node/Express)](https://github.com/GuxtavoLiu/cs2-weaponpaints-website)** - a maintained fork of [L1teD](https://github.com/L1teD/cs2-WeaponPaints-website) / [SwaggyMacro](https://github.com/SwaggyMacro/cs2-WeaponPaints-Website), adding stickers, offline inspect-link import, a loadout overview, float/pattern + StatTrak editing, and a multi-language UI (en / pt-BR / ru / zh-CN).
+
+> These are third-party projects, not maintained here. Use at your own discretion.
+
 ## Troubleshooting
 <details>
 **Skins are not changing:**


### PR DESCRIPTION
## What

Adds a small **"Alternative web panels (community)"** section to the README, right after **Web Features**, linking to community-maintained frontends that use the same database as the bundled PHP site.

## Why

The bundled PHP site under `website/` is a great minimal reference, but some server owners want extra features (stickers, inspect-link import, a loadout view, multi-language UI). A short, curated pointer helps them find maintained options without changing anything in this repo.

This is **purely additive**:
- The bundled PHP site stays the reference UI - nothing is removed or replaced.
- One paragraph + a "third-party, use at your own discretion" note.

## Disclosure

The first listed panel is **my own** project ([GuxtavoLiu/cs2-weaponpaints-website](https://github.com/GuxtavoLiu/cs2-weaponpaints-website)). It is a maintained fork of [L1teD](https://github.com/L1teD/cs2-WeaponPaints-website) / [SwaggyMacro](https://github.com/SwaggyMacro/cs2-WeaponPaints-Website) (credited inline). Happy to:
- list other community panels too so it reads as a neutral list rather than a single link,
- adjust wording, placement, or drop it entirely if you would rather not maintain a third-party list.

No code changes - README only.
